### PR TITLE
Use rubocop-govuk for linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,19 @@
-# Omakase Ruby styling for Rails
-inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+    - config/rspec.yml
 
-# Overwrite or add rules to create your own house style
+inherit_mode:
+  merge:
+    - Exclude
+
+# **************************************************************
+# TRY NOT TO ADD OVERRIDES IN THIS FILE
 #
-# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
-# Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false
-Layout/IndentationConsistency:
-  Enabled: true
-
-Layout/IndentationWidth:
-  Enabled: true
+# This repo is configured to follow the RuboCop GOV.UK styleguide.
+# Any rules you override here will cause this repo to diverge from
+# the way we write code in all other GOV.UK repos.
+#
+# See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
+# **************************************************************

--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,7 @@ group :development, :test do
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
 
-  # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
-  gem "rubocop-rails-omakase", require: false
+  gem "rubocop-govuk", require: false
 
   gem "rspec-rails"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "jbuilder"
 # gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem "tzinfo-data", platforms: %i[windows jruby]
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.9.1)
-    language_server-protocol (3.17.0.3)
+    language_server-protocol (3.17.0.4)
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -132,7 +132,6 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
     minitest (5.25.4)
     msgpack (1.7.5)
     net-imap (0.5.5)
@@ -145,11 +144,12 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.1)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.18.1-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.1-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.26.3)
-    parser (3.3.6.0)
+    parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
     psych (5.2.2)
@@ -233,22 +233,24 @@ GEM
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
-    rubocop-minitest (0.36.0)
-      rubocop (>= 1.61, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-performance (1.23.1)
-      rubocop (>= 1.48.1, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-capybara (2.21.0)
+      rubocop (~> 1.41)
+    rubocop-govuk (5.0.8)
+      rubocop (= 1.70.0)
+      rubocop-ast (= 1.37.0)
+      rubocop-capybara (= 2.21.0)
+      rubocop-rails (= 2.28.0)
+      rubocop-rake (= 0.6.0)
+      rubocop-rspec (= 3.3.0)
     rubocop-rails (2.28.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.52.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rails-omakase (1.0.0)
-      rubocop
-      rubocop-minitest
-      rubocop-performance
-      rubocop-rails
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (3.3.0)
+      rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
     securerandom (0.4.1)
@@ -265,8 +267,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (2.5.0)
-      mini_portile2 (~> 2.8.0)
+    sqlite3 (2.5.0-arm64-darwin)
+    sqlite3 (2.5.0-x86_64-linux-gnu)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.2)
@@ -310,7 +312,7 @@ DEPENDENCIES
   puma
   rails (= 8.0.1)
   rspec-rails
-  rubocop-rails-omakase
+  rubocop-govuk
   selenium-webdriver
   sprockets-rails
   sqlite3

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -14,13 +14,13 @@ class QuestionsController < ApplicationController
     end
   end
 
-  private
+private
 
-    def find_quiz
-      @quiz = Quiz.find(params[:quiz_id])
-    end
+  def find_quiz
+    @quiz = Quiz.find(params[:quiz_id])
+  end
 
-    def question_params
-      params.require(:question).permit(:content, :correct_answer)
-    end
+  def question_params
+    params.require(:question).permit(:content, :correct_answer)
+  end
 end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -35,13 +35,13 @@ class QuizzesController < ApplicationController
 
   def destroy
     @quiz = Quiz.find(params[:id])
-    @quiz.destroy
+    @quiz.destroy!
     redirect_to quizzes_url, notice: "Quiz was successfully destroyed."
-end
+  end
 
-    private
+private
 
-      def quiz_params
-        params.require(:quiz).permit(:title, :description)
-      end
+  def quiz_params
+    params.require(:quiz).permit(:title, :description)
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,12 +55,12 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger = ActiveSupport::Logger.new($stdout)
     .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,6 +3,6 @@
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+Rails.application.config.filter_parameters += %i[
+  passw email secret token _key crypt salt certificate otp ssn
 ]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,10 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'rspec/rails'
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -32,7 +32,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
-    Rails.root.join('spec/fixtures')
+    Rails.root.join("spec/fixtures"),
   ]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/requests/quizzes_spec.rb
+++ b/spec/requests/quizzes_spec.rb
@@ -3,25 +3,25 @@ require "rails_helper"
 RSpec.describe "Quizzes", type: :request do
   describe "GET index" do
     before do
-      Quiz.create(title: "First Quiz", description: "This is the first quiz")
-      Quiz.create(title: "Second Quiz", description: "This is the second quiz")
-      Quiz.create(title: "Third Quiz", description: "This is the third quiz")
-      Quiz.create(title: "Fourth Quiz", description: "This is the fourth quiz")
+      Quiz.create!(title: "First Quiz", description: "This is the first quiz")
+      Quiz.create!(title: "Second Quiz", description: "This is the second quiz")
+      Quiz.create!(title: "Third Quiz", description: "This is the third quiz")
+      Quiz.create!(title: "Fourth Quiz", description: "This is the fourth quiz")
     end
 
     it "gets all quizzes and checks the content" do
-        get "/quizzes"
-        expect(response).to have_http_status(:success)
-        expect(response.body).to include("First Quiz")
-        expect(response.body).to include("Second Quiz")
-        expect(response.body).to include("Third Quiz")
-        expect(response.body).to include("Fourth Quiz")
-      end
+      get "/quizzes"
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("First Quiz")
+      expect(response.body).to include("Second Quiz")
+      expect(response.body).to include("Third Quiz")
+      expect(response.body).to include("Fourth Quiz")
+    end
   end
 
   describe "GET show" do
     before do
-      @quiz = Quiz.create(title: "First Quiz", description: "This is the first quiz")
+      @quiz = Quiz.create!(title: "First Quiz", description: "This is the first quiz")
     end
 
     it "gets the first quiz" do
@@ -35,25 +35,25 @@ RSpec.describe "Quizzes", type: :request do
 
   describe "POST create" do
     it "sends a quiz request to create a quiz" do
-        expect {
-          post quizzes_path, params: { quiz: { title: "First Quiz", description: "This is the first quiz" } }
-        }.to change(Quiz, :count).by(1)
+      expect {
+        post quizzes_path, params: { quiz: { title: "First Quiz", description: "This is the first quiz" } }
+      }.to change(Quiz, :count).by(1)
 
-        new_quiz = Quiz.last
+      new_quiz = Quiz.last
 
-        expect(response).to redirect_to(quiz_path(new_quiz))
-        follow_redirect!
+      expect(response).to redirect_to(quiz_path(new_quiz))
+      follow_redirect!
 
-        expect(response).to have_http_status(:success)
-        expect(response.body).to include("First Quiz")
-        expect(response.body).to include("This is the first quiz")
-      end
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("First Quiz")
+      expect(response.body).to include("This is the first quiz")
+    end
   end
 
   describe "PATCH update" do
     before do
-        @quiz = Quiz.create(title: "First Quiz", description: "This is the first quiz")
-      end
+      @quiz = Quiz.create!(title: "First Quiz", description: "This is the first quiz")
+    end
 
     it "sends a PATCH request to update a quiz" do
       patch quiz_path(@quiz.id), params: { quiz: { title: "First Quiz", description: "I have updated the quiz" } }
@@ -69,8 +69,8 @@ RSpec.describe "Quizzes", type: :request do
 
   describe "DELETE delete" do
     before do
-      Quiz.create(title: "First Quiz", description: "This is the first quiz")
-      Quiz.create(title: "Second Quiz", description: "This is the second quiz")
+      Quiz.create!(title: "First Quiz", description: "This is the first quiz")
+      Quiz.create!(title: "Second Quiz", description: "This is the second quiz")
     end
 
     it "deletes a quiz and redirects to the quizzes index" do

--- a/spec/requests/quizzes_spec.rb
+++ b/spec/requests/quizzes_spec.rb
@@ -20,12 +20,10 @@ RSpec.describe "Quizzes", type: :request do
   end
 
   describe "GET show" do
-    before do
-      @quiz = Quiz.create!(title: "First Quiz", description: "This is the first quiz")
-    end
+    let(:quiz) { Quiz.create!(title: "First Quiz", description: "This is the first quiz") }
 
     it "gets the first quiz" do
-      get quiz_path(@quiz.id)
+      get quiz_path(quiz.id)
 
       expect(response).to have_http_status(:success)
       expect(response.body).to include("First Quiz")
@@ -51,14 +49,12 @@ RSpec.describe "Quizzes", type: :request do
   end
 
   describe "PATCH update" do
-    before do
-      @quiz = Quiz.create!(title: "First Quiz", description: "This is the first quiz")
-    end
+    let(:quiz) { Quiz.create!(title: "First Quiz", description: "This is the first quiz") }
 
     it "sends a PATCH request to update a quiz" do
-      patch quiz_path(@quiz.id), params: { quiz: { title: "First Quiz", description: "I have updated the quiz" } }
+      patch quiz_path(quiz.id), params: { quiz: { title: "First Quiz", description: "I have updated the quiz" } }
 
-      expect(response).to redirect_to(quiz_path(@quiz))
+      expect(response).to redirect_to(quiz_path(quiz))
       follow_redirect!
 
       expect(response).to have_http_status(:success)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end


### PR DESCRIPTION
This switches this project from using rubocop-rails-omakase to rubocop-govuk, this allows the code style here to be consistent with GOV.UK projects.