### PR TITLE
Implement Form Validation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,5 @@
 @import "govuk_publishing_components/components/input";
 @import "govuk_publishing_components/components/layout-footer";
 @import "govuk_publishing_components/components/radio";
+@import "govuk_publishing_components/components/error-alert";
+@import "govuk_publishing_components/components/error-message";

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -11,7 +11,7 @@ class QuestionsController < ApplicationController
     if @question.save
       redirect_to quiz_path(@quiz)
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -20,6 +20,8 @@ class QuestionsController < ApplicationController
   def update
     if @question.update(question_params)
       redirect_to quiz_path(@quiz)
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -16,7 +16,7 @@ class QuizzesController < ApplicationController
     if @quiz.save
       redirect_to @quiz, notice: "Quiz was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -29,7 +29,7 @@ class QuizzesController < ApplicationController
     if @quiz.update(quiz_params)
       redirect_to @quiz, notice: "Quiz was successfully updated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -8,6 +8,9 @@ class Question < ApplicationRecord
     option_d: "option_d",
   }
 
+  validates :content, :option_a, :option_b, :option_c, :option_d, presence: { message: "Field can't be blank" }
+  validates :correct_option, inclusion: { in: %w[option_a option_b option_c option_d], message: "Please select one of the options" }
+
   def correct_answer
     raise "No answer defined" if correct_option.blank?
 

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -1,5 +1,5 @@
 class Quiz < ApplicationRecord
   has_many :questions, -> { order(:id) }, dependent: :destroy
-  validates :title, presence: true
-  validates :description, presence: true
+  validates :title, presence: { message: "Please enter a title for your quiz" }
+  validates :description, presence: { message: "Please provide a description for your quiz" }
 end

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,38 +1,49 @@
+<% if @question.errors.any? %>
+  <%= render "govuk_publishing_components/components/error_alert", {
+    message: "There were errors with your submission. Please fix them below."
+  } %>
+<% end %>
+
 <%= form_with(model: [@quiz, @question], local: true) do |f| %>
   <%= render "govuk_publishing_components/components/input", {
     label: { text: "Question" },
     name: "question[content]",
     value: @question.content,
-    id: "question_content"
+    id: "question_content",
+    error_items: @question.errors[:content].map { |message| { text: message } }
   } %>
 
   <%= render "govuk_publishing_components/components/input", {
     label: { text: "Option A" },
     name: "question[option_a]",
     value: @question.option_a,
-    id: "question_option_a"
+    id: "question_option_a",
+    error_items: @question.errors[:option_a].map { |message| { text: message } }
   } %>
 
   <%= render "govuk_publishing_components/components/input", {
     label: { text: "Option B" },
     name: "question[option_b]",
     value: @question.option_b,
-    id: "question_option_b"
-  } %>
+    id: "question_option_b",
+    error_items: @question.errors[:option_b].map { |message| { text: message } }
+    } %>
 
   <%= render "govuk_publishing_components/components/input", {
     label: { text: "Option C" },
     name: "question[option_c]",
     value: @question.option_c,
-    id: "question_option_c"
-  } %>
+    id: "question_option_c",
+    error_items: @question.errors[:option_c].map { |message| { text: message } }
+    } %>
 
   <%= render "govuk_publishing_components/components/input", {
     label: { text: "Option D" },
     name: "question[option_d]",
     value: @question.option_d,
-    id: "question_option_d"
-  } %>
+    id: "question_option_d",
+    error_items: @question.errors[:option_d].map { |message| { text: message } }
+    } %>
 
   <%= render "govuk_publishing_components/components/radio", {
     heading: "Select the correct option",
@@ -42,8 +53,9 @@
       { value: "option_b", text: "Option B" },
       { value: "option_c", text: "Option C" },
       { value: "option_d", text: "Option D" }
-    ]
-  } %>
+    ],
+    error_items: @question.errors[:correct_option].map { |message| { text: message } }
+    } %>
 
   <%= f.submit "Save", class: "govuk-button" %>
 <% end %>

--- a/app/views/quizzes/_form.html.erb
+++ b/app/views/quizzes/_form.html.erb
@@ -1,0 +1,28 @@
+<% if @quiz.errors.any? %>
+  <%= render "govuk_publishing_components/components/error_alert", {
+    message: "There were errors with your submission. Please fix them below."
+  } %>
+<% end %>
+
+<%= form_with model: @quiz, local: true do |form| %>
+    <%= render "govuk_publishing_components/components/input", {
+          label: { text: "Title" },
+          name: "quiz[title]",
+          value: @quiz.title,
+          id: "quiz_title",
+          error_items: @quiz.errors[:title].map { |message| { text: message } }
+        } %>
+        
+    <%= render "govuk_publishing_components/components/input", {
+          label: { text: "Description" },
+          name: "quiz[description]",
+          value: @quiz.description,
+          id: "quiz_description",
+          error_items: @quiz.errors[:description].map { |message| { text: message } }
+        } %>
+        
+    <div class="govuk-form-group">
+      <%= render "govuk_publishing_components/components/button", { text: button_text, type: "submit" } %>
+    </div>
+  <% end %>
+  

--- a/app/views/quizzes/edit.html.erb
+++ b/app/views/quizzes/edit.html.erb
@@ -1,20 +1,30 @@
 <% content_for :page_title, "Edit a Quiz" %>
 <% content_for :back_link, quiz_path(@quiz) %>
 
+<% if @quiz.errors.any? %>
+  <%= render "govuk_publishing_components/components/error_alert", {
+    message: "There were errors with your submission. Please fix them below."
+  } %>
+<% end %>
+
 <%= form_with model: @quiz, local: true do |form| %>
   <%= render "govuk_publishing_components/components/input", {
         label: { text: "Title" },
         name: "quiz[title]",
         value: @quiz.title,
-      } %>
+        id: "quiz_title",
+        error_items: @quiz.errors[:title].map { |message| { text: message } }
+        } %>
+
   <%= render "govuk_publishing_components/components/input", {
         label: { text: "Description" },
         name: "quiz[description]",
         value: @quiz.description,
-      } %>
-      
+        id: "quiz_description",
+        error_items: @quiz.errors[:description].map { |message| { text: message } }
+        } %>
+
 <%= render "govuk_publishing_components/components/button", {
         text: "Update Quiz",
     } %>
-
 <% end %>

--- a/app/views/quizzes/edit.html.erb
+++ b/app/views/quizzes/edit.html.erb
@@ -1,30 +1,4 @@
 <% content_for :page_title, "Edit a Quiz" %>
 <% content_for :back_link, quiz_path(@quiz) %>
 
-<% if @quiz.errors.any? %>
-  <%= render "govuk_publishing_components/components/error_alert", {
-    message: "There were errors with your submission. Please fix them below."
-  } %>
-<% end %>
-
-<%= form_with model: @quiz, local: true do |form| %>
-  <%= render "govuk_publishing_components/components/input", {
-        label: { text: "Title" },
-        name: "quiz[title]",
-        value: @quiz.title,
-        id: "quiz_title",
-        error_items: @quiz.errors[:title].map { |message| { text: message } }
-        } %>
-
-  <%= render "govuk_publishing_components/components/input", {
-        label: { text: "Description" },
-        name: "quiz[description]",
-        value: @quiz.description,
-        id: "quiz_description",
-        error_items: @quiz.errors[:description].map { |message| { text: message } }
-        } %>
-
-<%= render "govuk_publishing_components/components/button", {
-        text: "Update Quiz",
-    } %>
-<% end %>
+<%= render "form", button_text: "Update Quiz" %>

--- a/app/views/quizzes/new.html.erb
+++ b/app/views/quizzes/new.html.erb
@@ -1,17 +1,27 @@
 <% content_for :page_title, "Create a New Quiz" %>
 <% content_for :back_link, quizzes_path %>
 
+<% if @quiz.errors.any? %>
+  <%= render "govuk_publishing_components/components/error_alert", {
+    message: "There were errors with your submission. Please fix them below."
+  } %>
+<% end %>
+
 <%= form_with model: @quiz, local: true do |form| %>
   <%= render "govuk_publishing_components/components/input", {
         label: { text: "Title" },
         name: "quiz[title]",
-      } %>
+        value: @quiz.title,
+        error_items: @quiz.errors[:title].map { |message| { text: message } }
+    } %>
   <%= render "govuk_publishing_components/components/input", {
         label: { text: "Description" },
         name: "quiz[description]",
+        value: @quiz.description,
+        error_items: @quiz.errors[:description].map { |message| { text: message } }
       } %>
+  
 <div class="govuk-form-group">
   <%= render "govuk_publishing_components/components/button", { text: "Create Quiz", type: "submit" } %>
 </div>
-
 <% end %>

--- a/app/views/quizzes/new.html.erb
+++ b/app/views/quizzes/new.html.erb
@@ -1,27 +1,4 @@
 <% content_for :page_title, "Create a New Quiz" %>
 <% content_for :back_link, quizzes_path %>
 
-<% if @quiz.errors.any? %>
-  <%= render "govuk_publishing_components/components/error_alert", {
-    message: "There were errors with your submission. Please fix them below."
-  } %>
-<% end %>
-
-<%= form_with model: @quiz, local: true do |form| %>
-  <%= render "govuk_publishing_components/components/input", {
-        label: { text: "Title" },
-        name: "quiz[title]",
-        value: @quiz.title,
-        error_items: @quiz.errors[:title].map { |message| { text: message } }
-    } %>
-  <%= render "govuk_publishing_components/components/input", {
-        label: { text: "Description" },
-        name: "quiz[description]",
-        value: @quiz.description,
-        error_items: @quiz.errors[:description].map { |message| { text: message } }
-      } %>
-  
-<div class="govuk-form-group">
-  <%= render "govuk_publishing_components/components/button", { text: "Create Quiz", type: "submit" } %>
-</div>
-<% end %>
+<%= render "form", button_text: "Create Quiz" %>

--- a/spec/requests/questions_spec.rb
+++ b/spec/requests/questions_spec.rb
@@ -31,6 +31,26 @@ RSpec.describe "Questions", type: :request do
     end
   end
 
+  describe "POST create with invalid parameters" do
+    it "does not create a new question and displays error messages" do
+      expect {
+        post quiz_questions_path(quiz), params: { question: {
+          content: "",
+          option_a: "Answer A",
+          option_b: "Answer B",
+          option_c: "Answer C",
+          option_d: "Answer D",
+          correct_option: "",
+        } }
+      }.not_to change(quiz.questions, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("There were errors with your submission. Please fix them below.")
+      expect(response.body).to include("Field can&#39;t be blank")
+      expect(response.body).to include("Please select one of the options")
+    end
+  end
+
   describe "GET edit" do
     let(:question) do
       quiz.questions.create!(
@@ -78,6 +98,29 @@ RSpec.describe "Questions", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Three")
       expect(response.body).to include("Four")
+    end
+  end
+
+  describe "PATCH update with invalid parameters" do
+    let(:question) do
+      quiz.questions.create!(
+        content: "One",
+        option_a: "Answer A",
+        option_b: "Answer B",
+        option_c: "Answer C",
+        option_d: "Answer D",
+        correct_option: "option_a",
+      )
+    end
+
+    it "does not update the question and re-renders the edit form" do
+      patch quiz_question_path(quiz, question), params: { question: {
+        content: "",
+        option_a: "",
+      } }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("There were errors with your submission. Please fix them below.")
+      expect(response.body.scan("Field can&#39;t be blank").size).to eq(2)
     end
   end
 

--- a/spec/requests/quizzes_spec.rb
+++ b/spec/requests/quizzes_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe "Quizzes", type: :request do
     end
   end
 
+  describe "POST create with invalid parameters" do
+    it "does not create a new quiz and displays error messages" do
+      expect {
+        post quizzes_path, params: { quiz: { title: "", description: "" } }
+      }.not_to change(Quiz, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("There were errors with your submission. Please fix them below.")
+      expect(response.body).to include("Please enter a title for your quiz")
+      expect(response.body).to include("Please provide a description for your quiz")
+    end
+  end
+
   describe "PATCH update" do
     let(:quiz) { Quiz.create!(title: "First Quiz", description: "This is the first quiz") }
 
@@ -60,6 +73,19 @@ RSpec.describe "Quizzes", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("First Quiz")
       expect(response.body).to include("I have updated the quiz")
+    end
+  end
+
+  describe "PATCH update with invalid parameters" do
+    let(:quiz) { Quiz.create!(title: "Valid Quiz", description: "Valid Description") }
+
+    it "does not update the quiz and displays error messages" do
+      patch quiz_path(quiz.id), params: { quiz: { title: "", description: "" } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("There were errors with your submission. Please fix them below.")
+      expect(response.body).to include("Please enter a title for your quiz")
+      expect(response.body).to include("Please provide a description for your quiz")
     end
   end
 


### PR DESCRIPTION
This PR introduces form validations across the Quiz app. In the models, validations have been added to both the Quiz and Question classes so that essential fields (such as title, description, question content, answer options, and the correct option) must be present before records are saved. This was done to improve data integrity by preventing invalid data from being stored in the database.

On the view side, forms have been updated to incorporate GOV.UK error components, providing the user with immediate feedback when validation fails. Error summary alerts are displayed at the top of the forms to notify the user of issues, while additional error messages appear next to each field with errors. Moreover, user input is retained on form re-rendering, so that users don’t lose the data they have already entered.