### PR TITLE
Configure app for Heroku deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,13 @@
 source "https://rubygems.org"
 
+ruby "~> #{File.read(File.join(__dir__, '.ruby-version')).strip}"
+
 gem "bootsnap", require: false
 gem "dartsass-rails", "~> 0.5.1"
 gem "govuk_publishing_components"
 gem "importmap-rails"
 gem "jbuilder"
+gem "pg"
 gem "puma"
 gem "rails", "8.0.2"
 gem "sprockets-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,6 +404,7 @@ GEM
     parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
+    pg (1.5.9)
     plek (5.2.1)
     pp (0.6.2)
       prettyprint
@@ -593,6 +594,7 @@ DEPENDENCIES
   govuk_publishing_components
   importmap-rails
   jbuilder
+  pg
   puma
   rails (= 8.0.2)
   rspec-rails
@@ -604,6 +606,9 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+
+RUBY VERSION
+   ruby 3.4.1p0
 
 BUNDLED WITH
    2.6.5

--- a/config/database.yml
+++ b/config/database.yml
@@ -28,5 +28,9 @@ test:
 # Similarly, if you deploy your application as a Docker container, you must
 # ensure the database is located in a persisted volume.
 production:
-  <<: *default
-  # database: path/to/persistent/storage/production.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("DATABASE_POOL", "12").to_i %>
+  template: template0
+  database: apprentice_quiz_app_production
+  url: <%= ENV["DATABASE_URL"]%>


### PR DESCRIPTION
In order to deploy to Heroku, we need to do a few things.

First we need to set the Ruby version in the Gemfile. While it does
technically build on Heroku without this, you get a warning and it'll
build with the latest Ruby version. For the sake of consistency, it's
probably best if it builds with the Ruby version we want (i.e. the one
set in the `.ruby-version` file). So we'll set the Ruby version in the
Gemfile by reading the contents of that file.

Heroku also doesn't like sqlite because the apps are backed by an
ephemeral filesystem which gets cleared periodically[1]. So the database
would get deleted every 24 hours, which clearly isn't ideal. Instead
they push you towards their postgres offering, which we'll use here.

We need to add the `pg` gem to the Gemfile so we can connect to
postgres, then configure the `database.yml` file to use postgres as the
database in production. To keep things as they are, we're still using
sqlite in development.

[1] https://devcenter.heroku.com/articles/sqlite3
